### PR TITLE
Update for issue #3

### DIFF
--- a/cointracker/querybot.py
+++ b/cointracker/querybot.py
@@ -21,18 +21,25 @@ def get_coin_list(num_coins):
     Returns a list of coin objects sorted by market cap using by calling coingecko API
     Read more: https://www.coingecko.com/en/api/documentation
     """
-    pages = math.ceil(num_coins / 250)
-    remainder = num_coins % 250
+    min_requestable_pages = math.ceil(num_coins / 250)
+    resuts_per_page = math.ceil(num_coins / min_requestable_pages)
+    
     coins = []
     url = 'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc'
     
     # iterates through a paginated API response to get all coins
-    for page in range(1, pages + 1):
-        coins += requests.get(url + f'&per_page=250&page={page}').json()
+    for pageNumber in range(min_requestable_pages):
+        response = requests.get(url + f'&per_page=250&page={pageNumber+1}').json() 
+        if response:
+            coins += response
+        else:
+            break
     
     # truncates excess coins from API call
-    if remainder != 0:
-        coins = coins[:-(250-remainder)]
+    remainder = len(coins) - num_coins
+    
+    if remainder > 0:
+        coins = coins[:-remainder]
     
     return coins    
 


### PR DESCRIPTION
Fix for Issue #3 : The API supports pagination with a fixed n results per page until or unless you reach the end of the set, so we can only minimize requests by the max supported results per page of 250 and minimize n remainder by trying to get close to the target number, so 600 would result in 3 pages of 200 vs 3 pages of 250. About as close to fixing issue #3 as we can get

Improvement: Moved remainder to check actual results against desired n results as actual results could be less than num_coins if requesting something larger than the set, there's an api error, or something else goes wrong. Similarly, the for loop will stop making requests once the first empty set comes back.